### PR TITLE
fix encoding of license pages

### DIFF
--- a/package/ui/licence_chs.html
+++ b/package/ui/licence_chs.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="zh">
     <head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>autorun - 许可证</title>
 	<link rel="stylesheet" type="text/css" href="dsm3.css"/>
     </head>

--- a/package/ui/licence_csy.html
+++ b/package/ui/licence_csy.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="cs">
     <head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>autorun - licence</title>
 	<link rel="stylesheet" type="text/css" href="dsm3.css"/>
     </head>

--- a/package/ui/licence_dan.html
+++ b/package/ui/licence_dan.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="da">
     <head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>autorun - licens</title>
 	<link rel="stylesheet" type="text/css" href="dsm3.css"/>
     </head>

--- a/package/ui/licence_enu.html
+++ b/package/ui/licence_enu.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
     <head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>autorun - licence</title>
 	<link rel="stylesheet" type="text/css" href="dsm3.css"/>
     </head>

--- a/package/ui/licence_fre.html
+++ b/package/ui/licence_fre.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="fr">
     <head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>autorun - licence</title>
 	<link rel="stylesheet" type="text/css" href="dsm3.css"/>
     </head>

--- a/package/ui/licence_ger.html
+++ b/package/ui/licence_ger.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="de">
     <head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>autorun - Lizenz</title>
 	<link rel="stylesheet" type="text/css" href="dsm3.css"/>
     </head>

--- a/package/ui/licence_hun.html
+++ b/package/ui/licence_hun.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="hu">
     <head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>autorun - licenc</title>
 	<link rel="stylesheet" type="text/css" href="dsm3.css"/>
     </head>

--- a/package/ui/licence_ita.html
+++ b/package/ui/licence_ita.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="it">
     <head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>autorun - licenza</title>
 	<link rel="stylesheet" type="text/css" href="dsm3.css"/>
     </head>

--- a/package/ui/licence_jpn.html
+++ b/package/ui/licence_jpn.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="ja">
     <head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>autorun - ライセンス</title>
 	<link rel="stylesheet" type="text/css" href="dsm3.css"/>
     </head>

--- a/package/ui/licence_nld.html
+++ b/package/ui/licence_nld.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="nl">
     <head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>autorun - licentie</title>
 	<link rel="stylesheet" type="text/css" href="dsm3.css"/>
     </head>

--- a/package/ui/licence_plk.html
+++ b/package/ui/licence_plk.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="pl">
     <head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>autorun - licencja</title>
 	<link rel="stylesheet" type="text/css" href="dsm3.css"/>
     </head>

--- a/package/ui/licence_ptb.html
+++ b/package/ui/licence_ptb.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="pt-BR">
     <head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>autorun - licença</title>
 	<link rel="stylesheet" type="text/css" href="dsm3.css"/>
     </head>

--- a/package/ui/licence_ptg.html
+++ b/package/ui/licence_ptg.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="pt-PT">
     <head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>autorun - licença</title>
 	<link rel="stylesheet" type="text/css" href="dsm3.css"/>
     </head>

--- a/package/ui/licence_rus.html
+++ b/package/ui/licence_rus.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="ru">
     <head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>автозапуск - лицензия</title>
 	<link rel="stylesheet" type="text/css" href="dsm3.css"/>
     </head>

--- a/package/ui/licence_spn.html
+++ b/package/ui/licence_spn.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="es">
     <head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>autorun - licencia</title>
 	<link rel="stylesheet" type="text/css" href="dsm3.css"/>
     </head>

--- a/package/ui/licence_sve.html
+++ b/package/ui/licence_sve.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="sv">
     <head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>autorun - licens</title>
 	<link rel="stylesheet" type="text/css" href="dsm3.css"/>
     </head>

--- a/package/ui/licence_trk.html
+++ b/package/ui/licence_trk.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="tr">
     <head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<title>autorun - li̇sans</title>
 	<link rel="stylesheet" type="text/css" href="dsm3.css"/>
     </head>


### PR DESCRIPTION
language specific license pages are lacking the charset=UTF-8 attribute for correct encoding

e.g. german version has `ZurÃ¼ck` instead of `Zurück` (all Umlaut had wrong encoding).
